### PR TITLE
Fix workflow in build_kraken.nf

### DIFF
--- a/build_kraken.nf
+++ b/build_kraken.nf
@@ -158,6 +158,6 @@ workflow {
     }
 
     build_kraken_db(db)
-    self_classify(db)
+    self_classify(build_kraken_db.out)
     build_bracken(self_classify.out) | add_food_info
 }


### PR DESCRIPTION
In the `build_kraken.nf` workflow in line 161, `self_classify()` needs `build_kraken_db.out`, otherwise it will run `build_kraken_db()` and `self_classify()` at the same time and produce an error in the `self_classify` step stating that not all the necessary files were downloaded (in our case the specific error was `kraken2: database ("./medi_db") does not contain necessary file taxo.k2d`) and the process will stop.
Thanks for making this great tool!